### PR TITLE
Add privacy policy page to Multigres site

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -121,6 +121,10 @@ const config: Config = {
               label: 'Blog',
               to: '/blog',
             },
+            {
+              label: 'Privacy Policy',
+              to: '/privacy',
+            },
           ],
         },
         {

--- a/src/pages/privacy.md
+++ b/src/pages/privacy.md
@@ -1,0 +1,110 @@
+---
+title: Privacy Policy
+description: Multigres Privacy Policy - Last Modified September 11, 2025
+---
+
+# Multigres Privacy Policy
+
+**Last Modified: September 11, 2025**
+
+Thank you for your interest in Multigres.com, a Supabase-owned website operated by Supabase, Inc. ("Supabase," "we," "our," or "us"). This Privacy Policy explains how we collect, use, disclose, and otherwise process information that identifies or can reasonably be linked to an individual ("personal information") when you visit or interact with our website at https://multigres.com (the "Site").
+
+This Privacy Policy applies only to the Site and any features, content, or communications offered through the Site (for example, contact forms, newsletter sign‑ups, and marketing pages). If you use other Supabase products or services (for example, the Supabase platform at https://supabase.com), the privacy notices for those services apply. Where we process personal information on behalf of a customer in connection with a Supabase service, we act as a processor under our data processing addendum; that processing is governed by the customer's agreement with Supabase and is not covered by this Privacy Policy.
+
+We may provide additional privacy disclosures for specific features or interactions that supplement this Privacy Policy.
+
+## Region‑Specific Disclosures
+
+- **California (Shine the Light / CCPA/CPRA):** We may use cookies and similar technologies for measurement and personalized advertising. You can manage preferences via your browser or applicable consent tools. You may also submit privacy requests at privacy@supabase.com.
+- **Nevada:** We do not sell personal information as "sale" is defined by Nevada law. Nevada residents may still submit an opt‑out request to privacy@supabase.com.
+- **EEA/UK/Switzerland:** See the "Privacy Disclosures for the European Economic Area, United Kingdom and Switzerland" below for information on lawful bases, transfers, and your rights.
+
+## What We Collect and How We Use It
+
+We collect personal information in three ways: (1) you provide it to us, (2) it is collected automatically, and (3) we receive it from third parties.
+
+### 1) Information You Provide
+
+- **Contact and communications:** When you submit a form, sign up to receive updates, or contact us, we collect the information you choose to provide (e.g., name, email address, company, message contents). We use this information to respond, provide requested information, and operate and improve the Site.
+- **Newsletter and marketing preferences:** If you subscribe to updates, we use your email to send communications consistent with your preferences. You can unsubscribe using the link in those emails.
+
+### 2) Information Collected Automatically
+
+When you visit the Site, we and our service providers automatically collect device and usage information using cookies, web beacons, pixels, and similar technologies. This may include IP address, general location (derived from IP), browser and device type, operating system, language, referring/exit pages, pages viewed, links clicked, and timestamps. We use this information to:
+
+- operate, secure, and debug the Site;
+- understand Site performance and usage (analytics);
+- measure campaign performance and, where permitted by law and your settings, personalize or measure advertising.
+
+You can manage cookie preferences via your browser settings and (where offered) our consent tools. Disabling cookies may affect Site functionality.
+
+### 3) Information from Third Parties
+
+We may receive limited personal information from service providers and partners (e.g., analytics, hosting, security, error monitoring, or marketing providers) and combine it with other information for the purposes described above.
+
+## How We Share Personal Information
+
+We share personal information as follows:
+
+- **Service providers:** With vendors that provide services such as hosting, security, analytics, communications, and marketing. These providers are bound by appropriate confidentiality and data protection commitments.
+- **Affiliates:** With other entities owned or controlled by Supabase that use personal information consistent with this Policy.
+- **Legal, safety, and compliance:** To comply with law or legal process; to protect the rights, safety, or property of Supabase, our users, or others; and to enforce our terms.
+- **Business transactions:** In connection with a merger, acquisition, financing, reorganization, or sale of all or a portion of our business or assets.
+- **With your direction or consent:** When you ask us to share information or otherwise consent to sharing.
+- **Aggregated/de‑identified information:** We may share information that does not identify you (e.g., aggregated statistics).
+
+## Your Choices and Controls
+
+- **Marketing emails:** You can unsubscribe by using the link in any email. We may still send you non‑marketing messages (e.g., legal or security notices).
+- **Cookies/Tracking:** Use your browser settings and any consent tools on the Site to manage cookies and similar technologies. Blocking cookies may impact functionality.
+- **Access/Deletion/Correction:** You may request access to, deletion of, or correction of personal information by emailing privacy@supabase.com. We may take steps to verify your identity and may deny requests as permitted by law.
+
+## Data Retention
+
+We retain personal information for as long as necessary to fulfill the purposes described in this Policy, including to comply with legal, accounting, or reporting obligations, resolve disputes, and enforce our agreements.
+
+## Security
+
+We use commercially reasonable technical and organizational measures designed to protect personal information we process through the Site. However, no method of transmission over the Internet or method of electronic storage is completely secure.
+
+## Third‑Party Links
+
+The Site may link to third‑party websites or services that we do not control. Their privacy practices are governed by their own policies. We encourage you to review those policies before providing personal information.
+
+## Children's Privacy
+
+The Site is not directed to children under 13, and we do not knowingly collect personal information from children under 13. If we learn that we have collected such information, we will take reasonable steps to delete it.
+
+## International Transfers
+
+We are a U.S. company and may process personal information in the United States and other countries that may not provide the same level of data protection as your home jurisdiction. Where required, we use appropriate safeguards (such as standard contractual clauses) for cross‑border transfers.
+
+## Changes to This Policy
+
+We may update this Privacy Policy from time to time. If we make material changes, we will take appropriate steps to notify you (e.g., by posting a notice on the Site). The "Last Modified" date above reflects the latest changes.
+
+## Contact Us
+
+For questions or requests, contact us at: privacy@supabase.com.
+
+---
+
+## Privacy Disclosures for the European Economic Area, United Kingdom, and Switzerland
+
+**Controller:** Supabase, Inc. is the controller for personal information collected via the Site.
+
+**Lawful Bases:** We process personal information for the following purposes and bases:
+
+- To operate and secure the Site (performance of contract where you access requested content; otherwise our legitimate interests in running our Site).
+- To respond to inquiries and send requested communications (performance of contract or our legitimate interests in communicating with you).
+- To send marketing communications (consent, which you can withdraw at any time).
+- To measure and improve the Site and campaigns (consent where required; otherwise our legitimate interests in analytics and improvement).
+- To comply with legal obligations and protect rights (legal obligation; legitimate interests).
+
+**Your Rights:** Subject to applicable law, you may request access, correction, deletion, restriction, or portability of your personal information, or object to processing based on legitimate interests, and withdraw consent at any time without affecting prior processing. You may lodge a complaint with your local data protection authority.
+
+**International Transfers:** Where we transfer personal information outside the EEA/UK/Switzerland, we rely on appropriate safeguards such as European Commission/UK‑approved standard contractual clauses.
+
+**Retention:** We retain personal information as described in "Data Retention" above and consistent with applicable laws and limitation periods.
+
+**Contact (EEA/UK/CH requests):** privacy@supabase.com


### PR DESCRIPTION
## Summary
- Added a comprehensive privacy policy page to the Multigres documentation site
- Added footer link for easy access to the privacy policy

## Changes
- Created new privacy policy page at `/privacy` with Supabase privacy policy content (dated September 11, 2025)
- Added "Privacy Policy" link to the site footer under the "Site" section

## Test plan
- [x] Build the Docusaurus site locally and verify the privacy policy page renders correctly at `/privacy`
- [x] Verify the footer link navigates to the privacy policy page
- [x] Check that the privacy policy content is properly formatted and readable

## Screenshots
<img width="1405" height="1273" alt="CleanShot 2025-09-12 at 09 24 45" src="https://github.com/user-attachments/assets/25782cc0-72c7-4dab-a192-4e39d56a66aa" />

<img width="1388" height="1443" alt="CleanShot 2025-09-12 at 09 28 12" src="https://github.com/user-attachments/assets/f4e102fe-bb3f-4735-9553-e62f19ad5178" />
