### PR TITLE
fix: add front-matter to TLA+ pg_rewind blog post

### DIFF
--- a/blog/2026-05-04-tla-pg-rewind.md
+++ b/blog/2026-05-04-tla-pg-rewind.md
@@ -1,6 +1,17 @@
+---
+slug: 2026/05/04/tla-pg-rewind
+title: 'How TLA+ Caught a Silent Data Divergence Bug in Postgres’s pg_rewind'
+authors: [mats]
+date: 2026-05-26
+tags: [postgres, multigres, tla+, pg_rewind]
+image: /img/blog/tla-pg-rewind.png
+---
+
 # How TLA+ Caught a Silent Data Divergence Bug in Postgres’s pg_rewind
 
 Multigres is Supabase's high-availability and horizontal scaling project for Postgres. The Multigres team at Supabase used [TLA+][TLAPlus] to model Postgres streaming replication and found a silent data-loss bug in [`pg_rewind`][pg_rewind]. Here's what we found and how we fixed it.
+
+<!--truncate-->
 
 ## Postgres HA with Streaming Replication
 

--- a/blog/2026-05-04-tla-pg-rewind.md
+++ b/blog/2026-05-04-tla-pg-rewind.md
@@ -2,7 +2,7 @@
 slug: 2026/05/04/tla-pg-rewind
 title: 'How TLA+ Caught a Silent Data Divergence Bug in Postgres’s pg_rewind'
 authors: [mats]
-date: 2026-05-26
+date: 2026-05-08
 tags: [postgres, multigres, tla+, pg_rewind]
 image: /img/blog/tla-pg-rewind.png
 ---


### PR DESCRIPTION
## Summary
- Adds the missing front-matter (slug, title, authors, date, tags, image) to the TLA+ / pg_rewind blog post so author details and metadata render correctly
- Inserts a `<!--truncate-->` marker so the blog index shows a proper summary instead of the full post

## Test plan
- [x] Run the docs site locally and verify the post renders with the correct title, author, and image
- [x] Confirm the blog listing page shows the truncated summary