### PR TITLE
blog: convert absolute multigres.com links to relative paths

### DIFF
--- a/blog/2025-10-20-generalized-consensus.md
+++ b/blog/2025-10-20-generalized-consensus.md
@@ -79,7 +79,7 @@ The series consists of 11 parts:
 
 ## Why This Matters for Multigres
 
-This work directly supports our goals for [Multigres](https://multigres.com). Postgres currently lacks a native consensus protocol. Existing solutions appear to use Raft as a black box, which limits their ability to optimize for Postgres's WAL replication model.
+This work directly supports our goals for [Multigres](/). Postgres currently lacks a native consensus protocol. Existing solutions appear to use Raft as a black box, which limits their ability to optimize for Postgres's WAL replication model.
 
 By building on this generalized framework, Multigres will support:
 - Flexible durability policies (cross-AZ, cross-region, custom combinations)

--- a/blog/2025-10-28-generalized-consensus-part4.md
+++ b/blog/2025-10-28-generalized-consensus-part4.md
@@ -113,7 +113,7 @@ There are other replication modes, but they don’t follow rule 1:
 - Async replication: The leader appends and applies the request, and asynchronously sends the events to the followers. This breaks rules 1a and 1b. This can lead to data loss if the leader node crashes.
 - Synchronous replication: The leader sends the request to the followers as final. The followers apply the change and send an ack to the leader. The leader applies the change when the ack is received. This follows rule 1a, but breaks rule 1b. This is because the followers apply the change before the request has met the durability criteria. This can lead to inconsistent “split-brain” states.
 
-*Postgres can rewind transactions. When a split-brain scenario happens, it is possible to identify the transactions that must be rewound to restore system consistency. Using this approach, it is possible to design a system that meets the necessary durability criteria. Details about this are covered in our earlier [blog post](https://multigres.com/blog/postgres-ha-full-sync#existing-replication-pitfalls).*
+*Postgres can rewind transactions. When a split-brain scenario happens, it is possible to identify the transactions that must be rewound to restore system consistency. Using this approach, it is possible to design a system that meets the necessary durability criteria. Details about this are covered in our earlier [blog post](/blog/postgres-ha-full-sync#existing-replication-pitfalls).*
 
 ### Rule 2
 

--- a/blog/2026-02-05-ai-parser-engineering.md
+++ b/blog/2026-02-05-ai-parser-engineering.md
@@ -12,7 +12,7 @@ description: "Same engineer. Same complexity. A year last time, eight weeks this
 
 Building a production-grade parser is an exercise in discipline. You need to translate thousands of grammar rules exactly. You need to catch subtle bugs that only surface on edge cases you've never seen. You need to verify every decision against a reference implementation. There are no shortcuts.
 
-I know this because I've done it before. I led the effort to build the MySQL parser for Vitess. That took over a year with help from talented contributors. So when we needed a Postgres parser for [Multigres](https://www.multigres.com), I expected a similar timeline.
+I know this because I've done it before. I led the effort to build the MySQL parser for Vitess. That took over a year with help from talented contributors. So when we needed a Postgres parser for [Multigres](/), I expected a similar timeline.
 
 It took eight weeks. 287,786 lines of code. 304 files. 130 commits. 71.2% test coverage. 2.5x faster than the cgo (Go's C interop) alternative.
 
@@ -28,7 +28,7 @@ Here's what I learned.
 
 ## Why build a parser at all?
 
-[Multigres](https://www.multigres.com) is Vitess for Postgres, a horizontally scalable layer that sits in front of your database. It distributes data across multiple database servers called shards. Each shard holds a subset of your data. When a query comes in, Multigres figures out which shard (or shards) should handle it and routes accordingly.
+[Multigres](/) is Vitess for Postgres, a horizontally scalable layer that sits in front of your database. It distributes data across multiple database servers called shards. Each shard holds a subset of your data. When a query comes in, Multigres figures out which shard (or shards) should handle it and routes accordingly.
 
 To route queries intelligently, we need to understand them. To understand them, we need a parser.
 

--- a/blog/2026-05-27-drop-in-postgres-proven-with-a-real-app.md
+++ b/blog/2026-05-27-drop-in-postgres-proven-with-a-real-app.md
@@ -54,10 +54,10 @@ Multigres splits that job in two. The MultiGateway is the tier that accepts clie
 
 How the gateway and pooler are built, and what the pooler does once it owns the connections, are their own topics. Earlier posts go deep on each piece:
 
-- [Two jobs, two processes](https://multigres.com/blog/two-jobs-two-processes) - why the pooler is part of the cluster rather than a sidecar in front of it.
-- [Per-user pools that share fairly](https://multigres.com/blog/per-user-pools-that-share-fairly) - per-user pooling and max-min fairness when demand is unknown.
-- [Pooling without choosing a mode](https://multigres.com/blog/pooling-without-choosing-a-mode) - how the pooler recycles connections automatically instead of making you pick transaction, session, or statement mode up front.
-- [One parse per query, no matter how many gateways](https://multigres.com/blog/one-parse-per-query-no-matter-how-many-gateways) - how prepared statements stay deduplicated on the backend even as you scale gateways out horizontally.
+- [Two jobs, two processes](/blog/two-jobs-two-processes) - why the pooler is part of the cluster rather than a sidecar in front of it.
+- [Per-user pools that share fairly](/blog/per-user-pools-that-share-fairly) - per-user pooling and max-min fairness when demand is unknown.
+- [Pooling without choosing a mode](/blog/pooling-without-choosing-a-mode) - how the pooler recycles connections automatically instead of making you pick transaction, session, or statement mode up front.
+- [One parse per query, no matter how many gateways](/blog/one-parse-per-query-no-matter-how-many-gateways) - how prepared statements stay deduplicated on the backend even as you scale gateways out horizontally.
 
 ## The 20,000-connection demo
 

--- a/blog/2026-05-27-multigres-cluster-bootstrap.md
+++ b/blog/2026-05-27-multigres-cluster-bootstrap.md
@@ -44,7 +44,7 @@ When the manifest applies, each service registers itself with the topology serve
 
 Poolers register next, each bound to a Postgres instance through pgctld. Every data directory is empty. Every pooler advertises itself as REPLICA, the safe default. The cluster still has no primary.
 
-This is the most fragile moment of a cluster's life. If a hand-rolled bootstrap script picked a primary now, two scripts could run in parallel and pick two different primaries. This is a split-brain. Multigres avoids it by coordinating leader appointment through MultiOrch, which runs as a small set of independent instances that agree on the leader through our [consensus protocol](https://multigres.com/blog/generalized-consensus-part1).
+This is the most fragile moment of a cluster's life. If a hand-rolled bootstrap script picked a primary now, two scripts could run in parallel and pick two different primaries. This is a split-brain. Multigres avoids it by coordinating leader appointment through MultiOrch, which runs as a small set of independent instances that agree on the leader through our [consensus protocol](/blog/generalized-consensus-part1).
 
 ## Seed backup first, then leader
 
@@ -94,4 +94,4 @@ That is what cluster bootstrapping looks like in Multigres. The result feels eff
 
 ## Further reading
 
-- [Multigres Architecture](https://multigres.com/docs/architecture)
+- [Multigres Architecture](/docs/architecture)

--- a/blog/2026-05-28-edge-cases-consensus-protects-you-from.md
+++ b/blog/2026-05-28-edge-cases-consensus-protects-you-from.md
@@ -66,4 +66,4 @@ These are strong safety guarantees that Multigres provides. Not only the obvious
 
 ## Further reading
 
-- [Generalized Consensus: Changing the Rules](https://multigres.com/blog/generalized-consensus-part8)
+- [Generalized Consensus: Changing the Rules](/blog/generalized-consensus-part8)

--- a/blog/2026-05-28-high-availability-from-first-principles.md
+++ b/blog/2026-05-28-high-availability-from-first-principles.md
@@ -7,7 +7,7 @@ tags: [postgres, multigres, high-availability, consensus, failover]
 
 # High availability from first principles
 
-In order to run services at scale and in a reliable way, high availability is a critical cornerstone. What it means in practice could vary from user to user. What follows is what high availability means in Multigres, what it is built on, and what a failover looks like in practice. The short version is that Multigres treats HA as a consensus problem, anchors that consensus in a [generalized](https://multigres.com/blog/generalized-consensus) model, and runs failovers that complete in a matter of seconds without violating durability.
+In order to run services at scale and in a reliable way, high availability is a critical cornerstone. What it means in practice could vary from user to user. What follows is what high availability means in Multigres, what it is built on, and what a failover looks like in practice. The short version is that Multigres treats HA as a consensus problem, anchors that consensus in a [generalized](/blog/generalized-consensus) model, and runs failovers that complete in a matter of seconds without violating durability.
 
 <!--truncate-->
 
@@ -100,4 +100,4 @@ Multigres can deliver this because it owns the problem as a cohesive solution. T
 
 ## Further reading
 
-- [Generalized Consensus: Recap](https://multigres.com/blog/generalized-consensus-part11)
+- [Generalized Consensus: Recap](/blog/generalized-consensus-part11)


### PR DESCRIPTION
## What

Rewrites the 12 absolute `https://multigres.com/...` references across 7 blog posts to relative internal links (`/blog/...`, `/docs/...`, `/`).

## Why

The blog posts were inconsistent — a mix of absolute and relative internal links. Relative paths resolve consistently across environments (local dev, preview, prod) and don't break if the domain changes.

## Changes

| File | Links |
|---|---|
| `2025-10-20-generalized-consensus.md` | `[Multigres]` → `/` |
| `2025-10-28-generalized-consensus-part4.md` | `postgres-ha-full-sync#existing-replication-pitfalls` |
| `2026-02-05-ai-parser-engineering.md` | 2× `[Multigres]` → `/` (also collapsed `www.` variant) |
| `2026-05-27-drop-in-postgres-proven-with-a-real-app.md` | 4 pooling-series posts |
| `2026-05-27-multigres-cluster-bootstrap.md` | `generalized-consensus-part1`, `/docs/architecture` |
| `2026-05-28-edge-cases-consensus-protects-you-from.md` | `generalized-consensus-part8` |
| `2026-05-28-high-availability-from-first-principles.md` | `generalized-consensus`, `generalized-consensus-part11` |

## Verification

- Production build passes with `onBrokenLinks: "throw"` — every internal link site-wide validated.
- All target routes return 200 on local dev server.
- Anchor `#existing-replication-pitfalls` confirmed against its source heading.
- Manually checked in the browser.