### PR TITLE
docs: We were using RAFT as acronym

### DIFF
--- a/content/blog/generalized-consensus-part4.md
+++ b/content/blog/generalized-consensus-part4.md
@@ -133,7 +133,7 @@ When the leader has to change, we have new decisions to make. We will talk about
 
 # How is this different from traditional consensus?
 
-The two-phase mechanism of sending out the requests, waiting for the necessary acks, and then sending out messages to apply the requests is nothing new. This is how RAFT also works. The part that differs is that the rules for what constitutes durable can be arbitrary.
+The two-phase mechanism of sending out the requests, waiting for the necessary acks, and then sending out messages to apply the requests is nothing new. This is how Raft also works. The part that differs is that the rules for what constitutes durable can be arbitrary.
 
 If we provided a plugin mechanism for the rules, these acks would be handled by the plugin, which would validate them against the durability rules. This would allow the main algorithm to remain agnostic of the durability policy.
 

--- a/content/blog/generalized-consensus-part5.md
+++ b/content/blog/generalized-consensus-part5.md
@@ -107,7 +107,7 @@ Raft offers a better approach: have the coordinators visit a set of overlapping 
 
 # The term number
 
-The assignment of an order between two independent nodes deciding to act is what Paxos calls a proposal number, and Raft calls a term number. This number must be universally unique, and is expected to increase monotonically. For clarity, we will use the RAFT terminology and refer to it as the term number. The rules around term numbers apply to all agents. This includes coordinators as well as leaders.
+The assignment of an order between two independent nodes deciding to act is what Paxos calls a proposal number, and Raft calls a term number. This number must be universally unique, and is expected to increase monotonically. For clarity, we will use the Raft terminology and refer to it as the term number. The rules around term numbers apply to all agents. This includes coordinators as well as leaders.
 
 To handle agents acting out of sequence, we’ll specify that a newer agent always supersedes an older one. This is a prerequisite for Rule 2a(i). To achieve this, we will make agents `recruit` nodes into their term:
 

--- a/content/blog/postgres-ha-full-sync.mdx
+++ b/content/blog/postgres-ha-full-sync.mdx
@@ -18,7 +18,7 @@ Multigres will bring the flexibility of a pluggable durability policy. There wil
 - cross-availability zone (cross-AZ): a replica in at least one other AZ must have my data
 - cross-region: same as cross-AZ, but for regions
 - at least two AZs: replicas in two distinct AZs must have my data
-- majority quorum: traditional consensus rules like RAFT
+- majority quorum: traditional consensus rules like Raft
 - etc.
 
 The advantages of policy based durability go beyond ease of use. Essentially, the policy does not need to depend on the number of nodes in the quorum. This flexibility allows you to deploy more nodes or additional zones without affecting the performance of the cluster.

--- a/content/docs/architecture.mdx
+++ b/content/docs/architecture.mdx
@@ -91,7 +91,7 @@ MultiOrch will implement a distributed consensus algorithm that will provide the
 
 MultiOrch will operate on an unmodified Postgres engine by using full sync replication. For a better experience, we recommend using the two-phase sync plug in (more details on this later).
 
-MultiOrch will be configurable to use a RAFT style majority quorum. It will also be configurable to support more advanced durability policies that don't depend on the quorum size. This will be achieved by using a new generalized consensus approach (covered later).
+MultiOrch will be configurable to use a Raft style majority quorum. It will also be configurable to support more advanced durability policies that don't depend on the quorum size. This will be achieved by using a new generalized consensus approach (covered later).
 
 MultiGateway will make use of the replicas to scale reads for situations where the application can tolerate eventual consistency. It will also be configurable to support consistent reads from replicas at the cost of waiting for writes to finish transmitting the data to the replicas.
 

--- a/content/docs/consensus/part-04.md
+++ b/content/docs/consensus/part-04.md
@@ -126,7 +126,7 @@ When the leader has to change, we have new decisions to make. We will talk about
 
 # How is this different from traditional consensus?
 
-The two-phase mechanism of sending out the requests, waiting for the necessary acks, and then sending out messages to apply the requests is nothing new. This is how RAFT also works. The part that differs is that the rules for what constitutes durable can be arbitrary.
+The two-phase mechanism of sending out the requests, waiting for the necessary acks, and then sending out messages to apply the requests is nothing new. This is how Raft also works. The part that differs is that the rules for what constitutes durable can be arbitrary.
 
 If we provided a plugin mechanism for the rules, these acks would be handled by the plugin, which would validate them against the durability rules. This would allow the main algorithm to remain agnostic of the durability policy.
 

--- a/content/docs/consensus/part-05.md
+++ b/content/docs/consensus/part-05.md
@@ -100,7 +100,7 @@ Raft offers a better approach: have the coordinators visit a set of overlapping 
 
 # The term number
 
-The assignment of an order between two independent nodes deciding to act is what Paxos calls a proposal number, and Raft calls a term number. This number must be universally unique, and is expected to increase monotonically. For clarity, we will use the RAFT terminology and refer to it as the term number. The rules around term numbers apply to all agents. This includes coordinators as well as leaders.
+The assignment of an order between two independent nodes deciding to act is what Paxos calls a proposal number, and Raft calls a term number. This number must be universally unique, and is expected to increase monotonically. For clarity, we will use the Raft terminology and refer to it as the term number. The rules around term numbers apply to all agents. This includes coordinators as well as leaders.
 
 To handle agents acting out of sequence, we’ll specify that a newer agent always supersedes an older one. This is a prerequisite for Rule 2a(i). To achieve this, we will make agents `recruit` nodes into their term:
 


### PR DESCRIPTION
# Desc
-  It was brought to my attention that we were writing RAFT as an acronym, when it is not. It should be Raft. 