### PR TITLE
feat(aeo): serve markdown via content negotiation

### DIFF
--- a/src/content/homepage.md
+++ b/src/content/homepage.md
@@ -1,0 +1,20 @@
+# Multigres
+
+> Multigres is a horizontally scalable architecture for PostgreSQL supporting multi-tenant, highly available, and globally distributed deployments, while staying true to standard Postgres.
+
+Multigres adds horizontal scaling, connection pooling, and cluster orchestration to PostgreSQL without forking it. It runs unmodified PostgreSQL workloads behind a wire-protocol-compatible proxy layer.
+
+## Components
+
+- **MultiGateway** — PostgreSQL wire-protocol proxy. Accepts client connections, parses SQL, applies routing rules, and routes queries to poolers.
+- **MultiPooler** — connection pooler managing pools per PostgreSQL instance, session state, prepared statements, and transactions.
+- **Pgctld** — PostgreSQL process manager: start/stop/restart instances, base backups, WAL archiving.
+- **MultiOrch** — cluster orchestration with Raft-based consensus, primary election, and failover coordination.
+- **MultiAdmin** — administrative API for cluster management operations.
+- **Operator** — Kubernetes operator for deploying and managing Multigres clusters.
+
+## Learn more
+
+- Documentation: https://multigres.com/docs
+- Blog: https://multigres.com/blog
+- Source: https://github.com/multigres/multigres

--- a/src/lib/blog-source.server.ts
+++ b/src/lib/blog-source.server.ts
@@ -64,3 +64,11 @@ export function getBlogPostListSummaries(posts: BlogPage[]) {
     seriesPart: post.data.seriesPart,
   }));
 }
+
+export async function getBlogLLMText(page: BlogPage) {
+  const processed = await page.data.getText('processed');
+
+  return `# ${page.data.title} (${page.url})
+
+${processed}`;
+}

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -18,6 +18,7 @@ import { Route as IndexRouteImport } from './routes/index'
 import { Route as BlogIndexRouteImport } from './routes/blog/index'
 import { Route as DocsChar123Char125DotmdRouteImport } from './routes/docs/{$}[.]md'
 import { Route as DocsSplatRouteImport } from './routes/docs/$'
+import { Route as BlogChar123Char125DotmdRouteImport } from './routes/blog/{$}[.]md'
 import { Route as BlogRssDotxmlRouteImport } from './routes/blog/rss[.]xml'
 import { Route as BlogSlugRouteImport } from './routes/blog/$slug'
 import { Route as ApiSearchRouteImport } from './routes/api/search'
@@ -68,6 +69,11 @@ const DocsSplatRoute = DocsSplatRouteImport.update({
   path: '/docs/$',
   getParentRoute: () => rootRouteImport,
 } as any)
+const BlogChar123Char125DotmdRoute = BlogChar123Char125DotmdRouteImport.update({
+  id: '/blog/{$}.md',
+  path: '/blog/{$}.md',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const BlogRssDotxmlRoute = BlogRssDotxmlRouteImport.update({
   id: '/blog/rss.xml',
   path: '/blog/rss.xml',
@@ -99,6 +105,7 @@ export interface FileRoutesByFullPath {
   '/api/search': typeof ApiSearchRoute
   '/blog/$slug': typeof BlogSlugRoute
   '/blog/rss.xml': typeof BlogRssDotxmlRoute
+  '/blog/{$}.md': typeof BlogChar123Char125DotmdRoute
   '/docs/$': typeof DocsSplatRoute
   '/docs/{$}.md': typeof DocsChar123Char125DotmdRoute
   '/blog/': typeof BlogIndexRoute
@@ -114,6 +121,7 @@ export interface FileRoutesByTo {
   '/api/search': typeof ApiSearchRoute
   '/blog/$slug': typeof BlogSlugRoute
   '/blog/rss.xml': typeof BlogRssDotxmlRoute
+  '/blog/{$}.md': typeof BlogChar123Char125DotmdRoute
   '/docs/$': typeof DocsSplatRoute
   '/docs/{$}.md': typeof DocsChar123Char125DotmdRoute
   '/blog': typeof BlogIndexRoute
@@ -130,6 +138,7 @@ export interface FileRoutesById {
   '/api/search': typeof ApiSearchRoute
   '/blog/$slug': typeof BlogSlugRoute
   '/blog/rss.xml': typeof BlogRssDotxmlRoute
+  '/blog/{$}.md': typeof BlogChar123Char125DotmdRoute
   '/docs/$': typeof DocsSplatRoute
   '/docs/{$}.md': typeof DocsChar123Char125DotmdRoute
   '/blog/': typeof BlogIndexRoute
@@ -147,6 +156,7 @@ export interface FileRouteTypes {
     | '/api/search'
     | '/blog/$slug'
     | '/blog/rss.xml'
+    | '/blog/{$}.md'
     | '/docs/$'
     | '/docs/{$}.md'
     | '/blog/'
@@ -162,6 +172,7 @@ export interface FileRouteTypes {
     | '/api/search'
     | '/blog/$slug'
     | '/blog/rss.xml'
+    | '/blog/{$}.md'
     | '/docs/$'
     | '/docs/{$}.md'
     | '/blog'
@@ -177,6 +188,7 @@ export interface FileRouteTypes {
     | '/api/search'
     | '/blog/$slug'
     | '/blog/rss.xml'
+    | '/blog/{$}.md'
     | '/docs/$'
     | '/docs/{$}.md'
     | '/blog/'
@@ -193,6 +205,7 @@ export interface RootRouteChildren {
   ApiSearchRoute: typeof ApiSearchRoute
   BlogSlugRoute: typeof BlogSlugRoute
   BlogRssDotxmlRoute: typeof BlogRssDotxmlRoute
+  BlogChar123Char125DotmdRoute: typeof BlogChar123Char125DotmdRoute
   DocsSplatRoute: typeof DocsSplatRoute
   DocsChar123Char125DotmdRoute: typeof DocsChar123Char125DotmdRoute
   BlogIndexRoute: typeof BlogIndexRoute
@@ -264,6 +277,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof DocsSplatRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/blog/{$}.md': {
+      id: '/blog/{$}.md'
+      path: '/blog/{$}.md'
+      fullPath: '/blog/{$}.md'
+      preLoaderRoute: typeof BlogChar123Char125DotmdRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/blog/rss.xml': {
       id: '/blog/rss.xml'
       path: '/blog/rss.xml'
@@ -305,6 +325,7 @@ const rootRouteChildren: RootRouteChildren = {
   ApiSearchRoute: ApiSearchRoute,
   BlogSlugRoute: BlogSlugRoute,
   BlogRssDotxmlRoute: BlogRssDotxmlRoute,
+  BlogChar123Char125DotmdRoute: BlogChar123Char125DotmdRoute,
   DocsSplatRoute: DocsSplatRoute,
   DocsChar123Char125DotmdRoute: DocsChar123Char125DotmdRoute,
   BlogIndexRoute: BlogIndexRoute,

--- a/src/routes/blog/{$}[.]md.ts
+++ b/src/routes/blog/{$}[.]md.ts
@@ -1,0 +1,21 @@
+import { createFileRoute, notFound } from '@tanstack/react-router';
+import { markdownPathToSlugs } from '@/lib/source';
+import { blogSource, getBlogLLMText } from '@/lib/blog-source.server';
+
+export const Route = createFileRoute('/blog/{$}.md')({
+  server: {
+    handlers: {
+      GET: async ({ params }) => {
+        const slugs = markdownPathToSlugs(params._splat?.split('/') ?? []);
+        const page = blogSource.getPage(slugs);
+        if (!page) throw notFound();
+
+        return new Response(await getBlogLLMText(page), {
+          headers: {
+            'Content-Type': 'text/markdown',
+          },
+        });
+      },
+    },
+  },
+});

--- a/src/routes/llms[.]txt.ts
+++ b/src/routes/llms[.]txt.ts
@@ -1,12 +1,29 @@
 import { source } from '@/lib/source';
+import { getBlogPosts } from '@/lib/blog-source.server';
 import { createFileRoute } from '@tanstack/react-router';
 import { llms } from 'fumadocs-core/source';
+
+const TAGLINE =
+  'Multigres is a horizontally scalable architecture for PostgreSQL supporting multi-tenant, highly available, and globally distributed deployments, while staying true to standard Postgres.';
 
 export const Route = createFileRoute('/llms.txt')({
   server: {
     handlers: {
       GET() {
-        return new Response(llms(source).index());
+        const docsIndex = llms(source).index();
+        const posts = getBlogPosts();
+        const blogSection = [
+          '## Blog',
+          '',
+          ...posts.map((post) => {
+            const desc = post.data.description ? `: ${post.data.description}` : '';
+            return `- [${post.data.title}](${post.url}.md)${desc}`;
+          }),
+        ].join('\n');
+
+        const body = `# Multigres\n\n> ${TAGLINE}\n\n${docsIndex}\n\n${blogSection}\n`;
+
+        return new Response(body);
       },
     },
   },

--- a/src/start.ts
+++ b/src/start.ts
@@ -1,24 +1,65 @@
 import { createMiddleware, createStart } from '@tanstack/react-start';
-import { isMarkdownPreferred } from 'fumadocs-core/negotiation';
-import { redirect } from '@tanstack/react-router';
-import { docsRoute } from '@/lib/shared';
-import { slugsToMarkdownPath } from './lib/source';
+import { getNegotiator } from 'fumadocs-core/negotiation';
+import { blogRoute, docsRoute } from '@/lib/shared';
+import { getLLMText, markdownPathToSlugs, source } from '@/lib/source';
+import { getBlogLLMText, blogSource } from '@/lib/blog-source.server';
+import homepageMarkdown from './content/homepage.md?raw';
 
-const llmMiddleware = createMiddleware().server(({ next, request }) => {
+const LIVE_FETCH_UA_RE =
+  /(?<![A-Za-z0-9])(?:Claude-User|Claude-Web|ChatGPT-User|PerplexityBot)(?![A-Za-z0-9-])/i;
+
+function isLiveFetchAgent(request: Request): boolean {
+  const ua = (request.headers.get('user-agent') ?? '').slice(0, 512);
+  return LIVE_FETCH_UA_RE.test(ua);
+}
+
+function prefersMarkdownByAccept(request: Request): boolean {
+  const preferred = getNegotiator(request).mediaTypes(['text/markdown', 'text/html'])[0];
+  return preferred === 'text/markdown';
+}
+
+function wantsMarkdown(request: Request): boolean {
+  return isLiveFetchAgent(request) || prefersMarkdownByAccept(request);
+}
+
+function markdownResponse(body: string): Response {
+  return new Response(body, {
+    headers: {
+      'Content-Type': 'text/markdown; charset=utf-8',
+      Vary: 'Accept',
+    },
+  });
+}
+
+const llmMiddleware = createMiddleware().server(async ({ next, request }) => {
   const url = new URL(request.url);
+  const pathname = url.pathname;
 
-  if (
-    url.pathname.startsWith(docsRoute) &&
-    !url.pathname.endsWith('.md') &&
-    isMarkdownPreferred(request)
-  ) {
-    const slugs = url.pathname
-      .slice(docsRoute.length)
+  if (pathname.endsWith('.md') || !wantsMarkdown(request)) {
+    return next();
+  }
+
+  if (pathname === '/') {
+    return markdownResponse(homepageMarkdown);
+  }
+
+  if (pathname.startsWith(docsRoute)) {
+    const slugs = markdownPathToSlugs(
+      pathname.slice(docsRoute.length).split('/').filter((v) => v.length > 0),
+    );
+    const page = source.getPage(slugs);
+    if (!page) return next();
+    return markdownResponse(await getLLMText(page));
+  }
+
+  if (pathname.startsWith(blogRoute)) {
+    const slugs = pathname
+      .slice(blogRoute.length)
       .split('/')
       .filter((v) => v.length > 0);
-    url.pathname = slugsToMarkdownPath(slugs).url;
-
-    throw redirect(url);
+    const page = blogSource.getPage(slugs);
+    if (!page) return next();
+    return markdownResponse(await getBlogLLMText(page));
   }
 
   return next();

--- a/src/start.ts
+++ b/src/start.ts
@@ -14,7 +14,7 @@ function isLiveFetchAgent(request: Request): boolean {
 }
 
 function prefersMarkdownByAccept(request: Request): boolean {
-  const preferred = getNegotiator(request).mediaTypes(['text/markdown', 'text/html'])[0];
+  const preferred = getNegotiator(request).mediaTypes(['text/html', 'text/markdown'])[0];
   return preferred === 'text/markdown';
 }
 
@@ -26,6 +26,7 @@ function markdownResponse(body: string): Response {
   return new Response(body, {
     headers: {
       'Content-Type': 'text/markdown; charset=utf-8',
+      'Cache-Control': 'public, max-age=0, s-maxage=86400, stale-while-revalidate=86400',
       Vary: 'Accept',
     },
   });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -16,12 +16,34 @@ export default defineConfig({
     tanstackStart({
       prerender: {
         enabled: true,
+        filter: ({ path }) =>
+          !path.startsWith('/docs') && !path.startsWith('/blog') && path !== '/',
       },
     }),
     react(),
     // please see https://tanstack.com/start/latest/docs/framework/react/guide/hosting#nitro for guides on hosting
     nitro({
       preset: 'vercel',
+      routeRules: {
+        '/': {
+          headers: {
+            'cache-control': 'public, s-maxage=86400, stale-while-revalidate=86400',
+            vary: 'Accept',
+          },
+        },
+        '/docs/**': {
+          headers: {
+            'cache-control': 'public, s-maxage=86400, stale-while-revalidate=86400',
+            vary: 'Accept',
+          },
+        },
+        '/blog/**': {
+          headers: {
+            'cache-control': 'public, s-maxage=86400, stale-while-revalidate=86400',
+            vary: 'Accept',
+          },
+        },
+      },
     }),
   ],
   resolve: {


### PR DESCRIPTION
## Summary
Multigres docs, blog, and homepage now serve clean Markdown to AI agents and Markdown-preferring clients at their canonical URLs, while browsers and search/training crawlers keep getting HTML. The previous middleware only handled `/docs/*` and, because every content route was prerendered to static HTML, never actually ran on Vercel, so `acceptmarkdown.com` scored the homepage 0/100. This serves Markdown in place for `/`, `/docs/*`, and `/blog/*`, honoring `Accept` q-values and live-fetch user-agents.

## Changes
- Negotiate Markdown for `/`, `/docs/*`, and `/blog/*`: serve it in place (HTTP 200, `Content-Type: text/markdown`, `Vary: Accept`) when the client prefers it, instead of redirecting to a `.md` URL
- Honor `Accept` q-values via the content negotiator (rank `text/html` vs `text/markdown`): serve Markdown only when ranked above HTML, so weighted headers and bare `*/*` correctly resolve to HTML
- Match live-fetch agents (`Claude-User`, `Claude-Web`, `ChatGPT-User`, `PerplexityBot`) and serve them Markdown; training crawlers (`GPTBot`, etc.) keep receiving HTML to avoid cloaking
- Exclude `/`, `/docs/*`, `/blog/*` from prerendering so the negotiation runs at request time on Vercel; add Nitro `routeRules` with `Cache-Control` + `Vary: Accept` to retain CDN caching
- Add a hand-authored homepage Markdown source served at `/`
- Add Markdown routes for blog posts (`/blog/<slug>.md`), matching the existing docs `.md` routes
- Lead `llms.txt` with the project name and a summary, and list blog posts alongside docs

## Testing
Verified on the Vite dev server (logic + user-agent matching):
- [x] `Accept: text/markdown` and a live-fetch UA (`ChatGPT-User`) return Markdown; a browser, bare `*/*`, and a training-crawler UA (`GPTBot`) return HTML
- [x] q-values honored: `text/html;q=0.9, text/markdown;q=0.1` returns HTML; `text/markdown;q=1.0 > text/html` returns Markdown
- [x] Build output confirms `/`, `/docs/*`, `/blog/*` are no longer prerendered

Verified on this PR's Vercel preview deploy (confirms negotiation runs at request time on Vercel, not just in dev):
- [x] `GET /` with `Accept: text/markdown` returns `text/markdown`
- [x] `GET /` with `Accept: text/html`, and bare `*/*`, return `text/html`
- [x] `GET /docs/architecture` with `Accept: text/markdown` returns `text/markdown`
- [x] `Accept: text/html;q=0.9, text/markdown;q=0.1` returns HTML; `text/html;q=0.5, text/markdown;q=1.0` returns Markdown

`acceptmarkdown.com` can only score production (it can't reach the auth-protected preview); confirming ~100 against `multigres.com` after this merges and deploys.

## Linear
- Part of GROWTH-914
