### PR TITLE
feat(aeo): structured data + robots AI signals

### DIFF
--- a/src/lib/json-ld.ts
+++ b/src/lib/json-ld.ts
@@ -1,0 +1,6 @@
+export function serializeJsonLd(data: unknown): string {
+  return JSON.stringify(data)
+    .replace(/</g, '\\u003c')
+    .replace(/>/g, '\\u003e')
+    .replace(/&/g, '\\u0026');
+}

--- a/src/routes/blog/$slug.tsx
+++ b/src/routes/blog/$slug.tsx
@@ -11,6 +11,9 @@ import { blogSource } from '@/lib/blog-source.server';
 import { docPageHeadingClassName } from '@/lib/typography';
 import { useFumadocsLoader } from 'fumadocs-core/source/client';
 import { Suspense } from 'react';
+import { serializeJsonLd } from '@/lib/json-ld';
+
+const logoUrl = 'https://multigres.com/img/og-image.png';
 
 export const Route = createFileRoute('/blog/$slug')({
   component: BlogPostPage,
@@ -25,48 +28,43 @@ export const Route = createFileRoute('/blog/$slug')({
     const image = loaderData?.image || '/img/og-image.png';
     const canonicalUrl = `https://multigres.com/blog/${params.slug}`;
 
+    const jsonLd: Record<string, unknown> = {
+      '@context': 'https://schema.org',
+      '@type': 'BlogPosting',
+      headline: loaderData?.title ?? 'Blog | Multigres',
+      description,
+      url: canonicalUrl,
+      publisher: {
+        '@type': 'Organization',
+        name: 'Multigres',
+        logo: { '@type': 'ImageObject', url: logoUrl },
+      },
+    };
+
+    jsonLd['image'] = image.startsWith('http') ? image : `https://multigres.com${image}`;
+    if (loaderData?.datePublished) jsonLd['datePublished'] = loaderData.datePublished;
+    if (loaderData?.authorName) {
+      jsonLd['author'] = { '@type': 'Person', name: loaderData.authorName };
+    }
+
     return {
       meta: [
-        {
-          title,
-        },
-        {
-          name: 'description',
-          content: description,
-        },
-        {
-          property: 'og:title',
-          content: title,
-        },
-        {
-          property: 'og:description',
-          content: description,
-        },
-        {
-          property: 'og:image',
-          content: image,
-        },
-        {
-          property: 'og:type',
-          content: 'article',
-        },
-        {
-          name: 'twitter:title',
-          content: title,
-        },
-        {
-          name: 'twitter:description',
-          content: description,
-        },
-        {
-          name: 'twitter:image',
-          content: image,
-        },
+        { title },
+        { name: 'description', content: description },
+        { property: 'og:title', content: title },
+        { property: 'og:description', content: description },
+        { property: 'og:image', content: image },
+        { property: 'og:type', content: 'article' },
+        { property: 'og:url', content: canonicalUrl },
+        { name: 'twitter:title', content: title },
+        { name: 'twitter:description', content: description },
+        { name: 'twitter:image', content: image },
       ],
-      links: [
+      links: [{ rel: 'canonical', href: canonicalUrl }],
+      scripts: [
         {
-          rel: 'canonical',
-          href: canonicalUrl,
+          type: 'application/ld+json',
+          children: serializeJsonLd(jsonLd),
         },
       ],
     };
@@ -79,11 +77,20 @@ const serverLoader = createServerFn({ method: 'GET' })
     const page = blogSource.getPage([slug]);
     if (!page) throw notFound();
 
+    const authorKeys = parseAuthorKeys(
+      (page.data.authors as string | string[] | undefined) ??
+        (page.data.author as string | undefined),
+    );
+    const authors = resolveAuthors(authorKeys);
+    const firstAuthor = authors[0];
+
     return {
       path: page.path,
       title: page.data.title,
       description: page.data.description,
       image: page.data.image,
+      datePublished: page.data.date ? page.data.date.toISOString() : undefined,
+      authorName: firstAuthor?.name,
     };
   });
 

--- a/src/routes/docs/$.tsx
+++ b/src/routes/docs/$.tsx
@@ -20,6 +20,7 @@ import { gitConfig } from '@/lib/shared';
 import { useFumadocsLoader } from 'fumadocs-core/source/client';
 import { Suspense } from 'react';
 import { useMDXComponents } from '@/components/mdx';
+import { serializeJsonLd } from '@/lib/json-ld';
 
 export const Route = createFileRoute('/docs/$')({
   component: Page,
@@ -36,46 +37,30 @@ export const Route = createFileRoute('/docs/$')({
 
     return {
       meta: [
-        {
-          title,
-        },
-        {
-          name: 'description',
-          content: description,
-        },
-        {
-          property: 'og:title',
-          content: title,
-        },
-        {
-          property: 'og:description',
-          content: description,
-        },
-        {
-          property: 'og:type',
-          content: 'article',
-        },
-        {
-          property: 'og:image',
-          content: '/img/og-image.png',
-        },
-        {
-          name: 'twitter:title',
-          content: title,
-        },
-        {
-          name: 'twitter:description',
-          content: description,
-        },
-        {
-          name: 'twitter:image',
-          content: '/img/og-image.png',
-        },
+        { title },
+        { name: 'description', content: description },
+        { property: 'og:title', content: title },
+        { property: 'og:description', content: description },
+        { property: 'og:type', content: 'article' },
+        { property: 'og:url', content: canonicalUrl },
+        { property: 'og:image', content: '/img/og-image.png' },
+        { name: 'twitter:title', content: title },
+        { name: 'twitter:description', content: description },
+        { name: 'twitter:image', content: '/img/og-image.png' },
       ],
-      links: [
+      links: [{ rel: 'canonical', href: canonicalUrl }],
+      scripts: [
         {
-          rel: 'canonical',
-          href: canonicalUrl,
+          type: 'application/ld+json',
+          children: serializeJsonLd({
+            '@context': 'https://schema.org',
+            '@type': 'TechArticle',
+            headline: loaderData?.title ?? 'Multigres Docs',
+            description,
+            url: canonicalUrl,
+            inLanguage: 'en',
+            publisher: { '@type': 'Organization', name: 'Multigres' },
+          }),
         },
       ],
     };
@@ -102,14 +87,7 @@ const serverLoader = createServerFn({
 const clientLoader = browserCollections.docs.createClientLoader({
   component(
     { toc, frontmatter, default: MDX },
-    // you can define props for the component
-    {
-      markdownUrl,
-      path,
-    }: {
-      markdownUrl: string;
-      path: string;
-    },
+    { markdownUrl, path }: { markdownUrl: string; path: string },
   ) {
     return (
       <DocsPage toc={toc} className="max-w-[800px] pb-16">

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,5 +1,43 @@
 import { createFileRoute } from '@tanstack/react-router';
 import LandingPage from '@/components/landing-page';
+import { serializeJsonLd } from '@/lib/json-ld';
+
+const description =
+  'A horizontally scalable Postgres architecture supporting multi-tenant, highly available, and globally distributed deployments.';
+
+const logoUrl = 'https://multigres.com/img/og-image.png';
+
+const jsonLd = [
+  {
+    '@context': 'https://schema.org',
+    '@type': 'Organization',
+    '@id': 'https://multigres.com/#organization',
+    name: 'Multigres',
+    url: 'https://multigres.com',
+    logo: logoUrl,
+    sameAs: ['https://github.com/multigres/multigres', 'https://twitter.com/multigres'],
+  },
+  {
+    '@context': 'https://schema.org',
+    '@type': 'WebSite',
+    '@id': 'https://multigres.com/#website',
+    name: 'Multigres',
+    url: 'https://multigres.com',
+    publisher: { '@id': 'https://multigres.com/#organization' },
+  },
+  {
+    '@context': 'https://schema.org',
+    '@type': 'SoftwareApplication',
+    name: 'Multigres',
+    applicationCategory: 'DeveloperApplication',
+    operatingSystem: 'Cross-platform',
+    description,
+    url: 'https://multigres.com',
+    publisher: { '@id': 'https://multigres.com/#organization' },
+    isAccessibleForFree: true,
+    license: 'https://www.apache.org/licenses/LICENSE-2.0',
+  },
+];
 
 export const Route = createFileRoute('/')({
   component: LandingPage,
@@ -10,8 +48,7 @@ export const Route = createFileRoute('/')({
       },
       {
         name: 'description',
-        content:
-          'A horizontally scalable Postgres architecture supporting multi-tenant, highly available, and globally distributed deployments.',
+        content: description,
       },
       {
         property: 'og:title',
@@ -19,8 +56,7 @@ export const Route = createFileRoute('/')({
       },
       {
         property: 'og:description',
-        content:
-          'A horizontally scalable Postgres architecture supporting multi-tenant, highly available, and globally distributed deployments.',
+        content: description,
       },
       {
         property: 'og:image',
@@ -35,6 +71,12 @@ export const Route = createFileRoute('/')({
       {
         rel: 'canonical',
         href: 'https://multigres.com/',
+      },
+    ],
+    scripts: [
+      {
+        type: 'application/ld+json',
+        children: serializeJsonLd(jsonLd),
       },
     ],
   }),

--- a/src/routes/robots[.]txt.ts
+++ b/src/routes/robots[.]txt.ts
@@ -7,7 +7,15 @@ export const Route = createFileRoute('/robots.txt')({
         const robots = `User-agent: *
 Allow: /
 
+User-agent: GPTBot
+User-agent: ClaudeBot
+User-agent: Google-Extended
+User-agent: PerplexityBot
+Allow: /
+
 Sitemap: https://multigres.com/sitemap.xml
+
+Content-Signal: ai-train=yes, search=yes, ai-input=yes
 `;
         return new Response(robots, {
           headers: {


### PR DESCRIPTION
## Summary
Adds structured data (JSON-LD) and explicit AI-crawler signals so search engines and AI assistants can understand and attribute Multigres content. Independent of #63 (the content-negotiation PR) and prerender-safe: the JSON-LD renders into the static HTML, and robots.txt is a server route, so neither depends on how pages are rendered.

## Changes
- Homepage: `Organization` + `WebSite` + `SoftwareApplication` JSON-LD (name, GitHub/Twitter `sameAs`, Apache-2.0 license)
- Docs pages: `TechArticle` JSON-LD + per-page `og:url`
- Blog posts: `BlogPosting` JSON-LD (headline, description, absolute image, `datePublished`, author, publisher) + per-page `og:url`; the blog serverLoader now also returns the post date and author for this
- robots.txt: explicit `Allow` block for `GPTBot` / `ClaudeBot` / `Google-Extended` / `PerplexityBot`, plus a `Content-Signal: ai-train=yes, search=yes, ai-input=yes` directive line
- Add a small `serializeJsonLd` helper that escapes `<`, `>`, `&` so the payload can't break out of the script tag

## Testing
Verified in the prerendered static build output (what crawlers actually receive):
- [x] Homepage HTML contains the `Organization` + `WebSite` + `SoftwareApplication` graph
- [x] `/docs/*` contains `TechArticle` + `og:url`; `/blog/*` contains `BlogPosting` + `og:url`
- [x] BlogPosting `image`, publisher `logo`, and Organization `logo` are absolute URLs (schema.org ignores relative ones)
- [x] robots.txt serves the AI-crawler allow block + `Content-Signal` line

Worth a pass through validator.schema.org once it deploys.

## Linear
- Part of GROWTH-914
