### PR TITLE
fix(blog): clean up listen notify post slug

### DIFF
--- a/content/blog/listen-notify.md
+++ b/content/blog/listen-notify.md
@@ -1,9 +1,9 @@
 ---
 title: "How Multigres Supports LISTEN/NOTIFY Across Pooled Connections"
+slug: "listen-notify"
 description: "LISTEN/NOTIFY is a per-session feature, and Multigres pools connections away from clients. Here's how we keep Postgres's pub/sub working when no client owns a backend session."
-date: "2026-06-23"
+date: "2026-07-02"
 author: "haritabh"
-image: "/img/blog/listen-notify/establish-pooler-owned-listener.png"
 tags: [postgres, multigres, listen-notify, connection-pooling]
 ---
 

--- a/source.config.ts
+++ b/source.config.ts
@@ -33,6 +33,7 @@ export const blog = defineCollections({
         }
         return parsed;
       }),
+    slug: z.string().optional(),
     author: z.string().optional(),
     authors: z.array(z.string()).optional(),
     tags: z.array(z.string()).optional(),

--- a/src/lib/blog-source.server.ts
+++ b/src/lib/blog-source.server.ts
@@ -1,4 +1,5 @@
 import { loader } from 'fumadocs-core/source';
+import { slugsFromData } from 'fumadocs-core/source/plugins/slugs';
 import { blog } from 'collections/server';
 import { lucideIconsPlugin } from 'fumadocs-core/source/lucide-icons';
 import { toFumadocsSource } from 'fumadocs-mdx/runtime/server';
@@ -8,6 +9,7 @@ import { blogRoute, siteUrl } from './shared';
 export const blogSource = loader({
   source: toFumadocsSource(blog, []),
   baseUrl: blogRoute,
+  slugs: slugsFromData(),
   plugins: [lucideIconsPlugin()],
 });
 

--- a/vercel.json
+++ b/vercel.json
@@ -13,6 +13,11 @@
       "permanent": true
     },
     {
+      "source": "/blog/2026-05-24-listen-notify",
+      "destination": "/blog/listen-notify",
+      "permanent": true
+    },
+    {
       "source": "/consensus",
       "destination": "/docs/consensus/part-00",
       "permanent": true


### PR DESCRIPTION
## Summary
- rename the LISTEN/NOTIFY blog file to remove the date from the generated URL
- add a frontmatter `slug` and configure blog slugs to read from frontmatter
- remove the preview image from the blog index and update the post date to 2026-07-02
- add a redirect from the current dated production URL to `/blog/listen-notify`

## Testing
- Verified locally at `http://127.0.0.1:3000/blog/listen-notify`
- Verified the blog index links to `/blog/listen-notify` and no longer includes the LISTEN/NOTIFY preview image
- `pnpm types:check` currently fails on pre-existing TypeScript errors unrelated to this change
