### PR TITLE
fix: drop ua-based markdown switching

### DIFF
--- a/src/start.ts
+++ b/src/start.ts
@@ -5,21 +5,9 @@ import { getLLMText, markdownPathToSlugs, source } from '@/lib/source';
 import { getBlogLLMText, blogSource } from '@/lib/blog-source.server';
 import homepageMarkdown from './content/homepage.md?raw';
 
-const LIVE_FETCH_UA_RE =
-  /(?<![A-Za-z0-9])(?:Claude-User|Claude-Web|ChatGPT-User|PerplexityBot)(?![A-Za-z0-9-])/i;
-
-function isLiveFetchAgent(request: Request): boolean {
-  const ua = (request.headers.get('user-agent') ?? '').slice(0, 512);
-  return LIVE_FETCH_UA_RE.test(ua);
-}
-
 function prefersMarkdownByAccept(request: Request): boolean {
   const preferred = getNegotiator(request).mediaTypes(['text/html', 'text/markdown'])[0];
   return preferred === 'text/markdown';
-}
-
-function wantsMarkdown(request: Request): boolean {
-  return isLiveFetchAgent(request) || prefersMarkdownByAccept(request);
 }
 
 function markdownResponse(body: string): Response {
@@ -40,7 +28,7 @@ const llmMiddleware = createMiddleware().server(async ({ next, request }) => {
   const explicitMarkdown = pathname.endsWith(MARKDOWN_EXT);
 
   // Explicit `.md` URLs always serve markdown; bare URLs only when the client prefers it.
-  if (!explicitMarkdown && !wantsMarkdown(request)) {
+  if (!explicitMarkdown && !prefersMarkdownByAccept(request)) {
     return next();
   }
 


### PR DESCRIPTION
## Summary
The middleware served markdown based on user-agent matching, but markdown responses only declare `Vary: Accept`, so the CDN cache key ignores the user agent and whichever variant is computed first gets cached for every client. I observed this live as deterministic variant poisoning: byte-identical `ChatGPT-User` requests received `text/html` on GET and `text/markdown` on HEAD for the same cached URL. This change removes the UA branch so content varies only by the `Accept` header, which makes the declared `Vary` truthful and the poisoning structurally impossible. Clients that want markdown still get it via `Accept` negotiation or explicit `.md` URLs; separately, the `ChatGPT-User` agent's reader currently hard-fails on markdown it receives via UA matching (details in GROWTH-973), so consistently serving it the fully server-rendered HTML also fixes readability in that assistant.

## Changes
- Remove `LIVE_FETCH_UA_RE`/`isLiveFetchAgent` from `src/start.ts`; bare URLs serve markdown only when the `Accept` header prefers it, explicit `.md` URLs unchanged

## Testing
Tested locally:
- [x] Dev-server matrix: `ChatGPT-User` and `Claude-User` UA GETs return `text/html`; `Accept: text/markdown` returns `text/markdown`; GET and HEAD agree
- [x] Claude's real fetcher keeps receiving markdown (it sends `Accept: text/markdown, text/html, */*`, which wins negotiation)

Verify in production post-deploy (dev harness cannot exercise these):
- [ ] GET/HEAD content-type consistency on a previously cached blog URL
- [ ] Explicit `.md` URLs still serve markdown

## Linear
- fixes GROWTH-973
